### PR TITLE
jmpのバグ

### DIFF
--- a/Plugin64/injector.hpp
+++ b/Plugin64/injector.hpp
@@ -612,9 +612,9 @@ namespace Injector
 	{
 		auto p = GetBranchDestination(at, vp);
 
-		auto offset = GetRelativeOffset(dest, at + 4);
+		auto offset = GetRelativeOffset(dest, at + 1 + 4);
 
-		if (offset > 0xFFFFFFFF) {
+		if (offset > 0x7FFFFFFF) {
 			//WriteMemory<uint8_t>(at, 0x48, vp); // REX.w ‐ 1=オペランドサイズを64ビットにする。
 			WriteMemory<uint8_t>(at, 0xFF, vp); // operand①
 			// Mod/R: [RIP + disp32]を意味する


### PR DESCRIPTION
> https://www.felixcloutier.com/x86/jmp
> E9 cd    JMP rel32    D    Valid    Valid    Jump near, relative, RIP = RIP + 32-bit displacement sign extended to 64-bits

とあって、x86とx64で解釈が違います。従い `E9 00 00 00 70` は両方とも `jmp 0x70000005` になる一方、`E9 00 00 00 80`は`jmp 0x80000005`と`jmp 0xffffffff80000005`になります。下記で試せます。

> https://defuse.ca/online-x86-assembler.htm#disassembly2
> Online x86 and x64 Intel Instruction Assembler
> Easily find out which bytes your x86 ASM instructions assemble to.

なので、この雑に追加したスイッチが間違っているということでした

https://github.com/matanki-saito/EU4dll/blob/998afa13234b792c27fe5f72094a5989c801d49e/Plugin64/injector.hpp#L616